### PR TITLE
V1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Build the mod using Arma 3 Tools (Addon Builder) or compatible PBO packing tools
 - ZeusJukebox cannot know whether players have turned their music volume down/off in game settings.
 - Multiple Zeuses acting simultaneously may have race conditions (first action wins).
 - **Music without duration**: If a music track has no duration declared in its config, it will show `0:00` in the music list and be defaulted to 3 minutes (180 seconds) when played. This can lead to music continuing to play silently after the actual track ends, or tracks being cut off early if they are longer than 3 minutes.
+- **Mission music shadows addon music with the same class name**: If a mission defines a `CfgMusic` class that shares its name with an addon track, the addon entry is hidden from the music list. Arma 3 resolves `playMusic` to the mission version in this case, so only the mission entry is shown. The addon track is inaccessible for the duration of that mission.
 
 ## Compatibility
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -285,6 +285,7 @@ if (count _queue == 0) exitWith { false };
 2. **ACE Hearing conflict**: Fade functionality disabled when ACE Hearing is loaded and `enableCombatDeafness` or `enableNoiseDucking` is enabled
 3. **Race conditions**: Multiple Zeuses acting simultaneously may conflict
 4. **No undo**: Actions cannot be reverted (e.g., queue removal)
+5. **Mission music shadows addon music with the same class name**: If a mission's `description.ext` defines a `CfgMusic` class that also exists in a loaded addon, the addon entry is hidden from the music list. `playMusic` resolves both to the mission version anyway (mission config takes precedence), so only the mission entry is shown. The addon's track is inaccessible for the duration of that mission.
 
 ## Summary
 

--- a/doc/steam_workshop/WorkshopDescription.md
+++ b/doc/steam_workshop/WorkshopDescription.md
@@ -45,6 +45,7 @@ The Beta Version is available [url=https://steamcommunity.com/sharedfiles/filede
 [*]When using [b]ACE[/b], fading out music is disabled if [b]Enable Combat Deafness[/b] or [b]Enable Noise Ducking Effect[/b] is turned on, as those settings cause ACE to continuously override music volume. If both are disabled, fading works normally.
 [*]If music is played from another source than the Zeus Jukebox, it does not get detected as currently playing.
 [*][b]Music without duration:[/b] If a music track has no duration declared in its config, it will show [b]0:00[/b] in the music list and will be defaulted to 3 minutes (180 seconds) when played. This can lead to music continuing to play silently after the actual track ends, or tracks being cut off early if they are longer than 3 minutes.
+[*][b]Mission music shadows addon music with the same class name[b]: If a mission's `description.ext` defines a `CfgMusic` class that also exists in a loaded addon, the addon entry is hidden from the music list. `playMusic` resolves both to the mission version anyway (mission config takes precedence), so only the mission entry is shown. The addon's track is inaccessible for the duration of that mission.
 [/list]
 
 Other than that, there are currently no known issues.

--- a/doc/steam_workshop/WorkshopDescription.md
+++ b/doc/steam_workshop/WorkshopDescription.md
@@ -45,7 +45,7 @@ The Beta Version is available [url=https://steamcommunity.com/sharedfiles/filede
 [*]When using [b]ACE[/b], fading out music is disabled if [b]Enable Combat Deafness[/b] or [b]Enable Noise Ducking Effect[/b] is turned on, as those settings cause ACE to continuously override music volume. If both are disabled, fading works normally.
 [*]If music is played from another source than the Zeus Jukebox, it does not get detected as currently playing.
 [*][b]Music without duration:[/b] If a music track has no duration declared in its config, it will show [b]0:00[/b] in the music list and will be defaulted to 3 minutes (180 seconds) when played. This can lead to music continuing to play silently after the actual track ends, or tracks being cut off early if they are longer than 3 minutes.
-[*][b]Mission music shadows addon music with the same class name[b]: If a mission's `description.ext` defines a `CfgMusic` class that also exists in a loaded addon, the addon entry is hidden from the music list. `playMusic` resolves both to the mission version anyway (mission config takes precedence), so only the mission entry is shown. The addon's track is inaccessible for the duration of that mission.
+[*][b]Mission music shadows addon music with the same class name[/b]: If a mission's `description.ext` defines a `CfgMusic` class that also exists in a loaded addon, the addon entry is hidden from the music list. `playMusic` resolves both to the mission version anyway (mission config takes precedence), so only the mission entry is shown. The addon's track is inaccessible for the duration of that mission.
 [/list]
 
 Other than that, there are currently no known issues.

--- a/functions/actions/preview/fn_onPreviewPlay.sqf
+++ b/functions/actions/preview/fn_onPreviewPlay.sqf
@@ -31,11 +31,9 @@ private _pausedAt = uiNamespace getVariable ["ZeusJukebox_previewPausedAt", 0];
 if (missionNamespace getVariable ["ZeusJukebox_isFading", false]) then {
 	0 fadeMusic 1;
 };
-// Use explicit sound file path when available so the correct source file plays
-// even when the class name exists in both an addon and the mission config.
-private _previewSoundFile = uiNamespace getVariable ["ZeusJukebox_previewSoundFile", ""];
-private _playTarget = if (_previewSoundFile != "") then { _previewSoundFile } else { _currentPreviewTrack };
-playMusic [_playTarget, _pausedAt];
+// Use the class name for playMusic — the [filePath, offset] form does not produce audio.
+// The sound file path stored in uiNamespace is kept for queue/track-info use.
+playMusic [_currentPreviewTrack, _pausedAt];
 
 // Auto-mute Currently Playing for Zeus when previewing
 // (so Zeus doesn't hear both preview and currently playing at once)
@@ -58,13 +56,16 @@ uiNamespace setVariable ["ZeusJukebox_previewPlaying", true];
 [] call ZeusJukebox_fnc_updateUiPreviewArea;
 
 // Start progress update loop
-[] spawn {
+private _handle = [] spawn {
     disableSerialization;
 
     while {uiNamespace getVariable ["ZeusJukebox_previewPlaying", false]} do {
         [] call ZeusJukebox_fnc_handlePreviewMusicProgress;
         sleep 0.1;
     };
+
+    uiNamespace setVariable ["ZeusJukebox_previewUpdateHandle", scriptNull];
 };
+uiNamespace setVariable ["ZeusJukebox_previewUpdateHandle", _handle];
 
 true

--- a/functions/remote/fn_remotePlaySong.sqf
+++ b/functions/remote/fn_remotePlaySong.sqf
@@ -43,27 +43,10 @@ missionNamespace setVariable ["ZeusJukebox_currentlyPlayingDuration", _duration,
 missionNamespace setVariable ["ZeusJukebox_currentlyPlayingActive", true, true];
 missionNamespace setVariable ["ZeusJukebox_currentlyPlayingSoundFile", _soundFile, true];
 
-// Use explicit sound file path when provided; otherwise fall back to class name so the
-// engine resolves the audio normally (e.g. for import-by-class-name or legacy callers).
-private _playTarget = if (_soundFile != "") then { _soundFile } else { _trackClass };
-
-// Escape single quotes in play target to prevent code injection
-private _playTargetEscaped = _playTarget;
-if (_playTarget find "'" >= 0) then {
-	private _chars = toArray _playTarget;
-	private _result = "";
-	{
-		if (_x == 39) then {
-			_result = _result + "''";
-		} else {
-			_result = _result + toString [_x];
-		};
-	} forEach _chars;
-	_playTargetEscaped = _result;
-};
-
-// remote Execute code block to play music on each client
-private _remoteCode = compile format ["private _wasPreviewPlaying = uiNamespace getVariable ['ZeusJukebox_previewPlaying', false]; private _previewTrack = uiNamespace getVariable ['ZeusJukebox_previewTrack', '']; if (_wasPreviewPlaying && _previewTrack != '') then {} else { playMusic ['%1', %2]; };", _playTargetEscaped, _startPosition];
+// Always use the class name for playMusic — raw file paths from CfgMusic's sound[]
+// array reference packed PBO files that cannot be opened directly by playMusic.
+// The _soundFile is kept for display/metadata purposes only.
+private _remoteCode = compile format ["private _wasPreviewPlaying = uiNamespace getVariable ['ZeusJukebox_previewPlaying', false]; private _previewTrack = uiNamespace getVariable ['ZeusJukebox_previewTrack', '']; if (_wasPreviewPlaying && _previewTrack != '') then {} else { playMusic ['%1', %2]; };", _trackClass, _startPosition];
 _remoteCode remoteExec ["call", 0, false];
 
 // Terminate any existing progress loop before spawning new one

--- a/functions/ui/fn_updateUiCurrentlyPlaying.sqf
+++ b/functions/ui/fn_updateUiCurrentlyPlaying.sqf
@@ -64,10 +64,10 @@ if (_currentTrack == "") exitWith {
 // Track exists - hide overlay
 if (!isNull _noSongOverlay) then { _noSongOverlay ctrlShow false; };
 
-// Get track info from config
-private _config = configFile >> "CfgMusic" >> _currentTrack;
+// Get track info from config — mission takes priority, matching playMusic resolution.
+private _config = missionConfigFile >> "CfgMusic" >> _currentTrack;
 if (!isClass _config) then {
-	_config = missionConfigFile >> "CfgMusic" >> _currentTrack;
+	_config = configFile >> "CfgMusic" >> _currentTrack;
 };
 
 private _displayName = _currentTrack;

--- a/functions/ui/fn_updateUiMusicList.sqf
+++ b/functions/ui/fn_updateUiMusicList.sqf
@@ -64,9 +64,16 @@ if (count _groupedTracks == 0 || _forceRebuild) then {
 
     diag_log format ["[ZeusJukebox] Music classes found - Addons: %1, Mission: %2", count _allModMusicClasses, count _missionMusicClasses];
 
-    // Tag each entry with its source. Same class name can appear twice (once from a mod,
-    // once from the mission) — they belong in different categories.
-    private _allEntries = (_allModMusicClasses apply { [_x, false] }) + (_missionMusicClasses apply { [_x, true] });
+    // Build a set of mission class names for O(1) lookup.
+    // When the same class name exists in both an addon and the mission, the mission
+    // version takes precedence for playMusic, so the addon entry is suppressed to
+    // avoid a misleading duplicate that would play the same (mission) audio.
+    private _missionClassSet = createHashMap;
+    { _missionClassSet set [configName _x, true]; } forEach _missionMusicClasses;
+
+    private _allEntries = (
+        (_allModMusicClasses select { !(_missionClassSet getOrDefault [configName _x, false]) }) apply { [_x, false] }
+    ) + (_missionMusicClasses apply { [_x, true] });
 
     // If no tracks found, show a message
     if (count _allEntries == 0) exitWith {

--- a/functions/utilities/fn_getTrackConfig.sqf
+++ b/functions/utilities/fn_getTrackConfig.sqf
@@ -16,11 +16,11 @@ params [["_className", "", [""]]];
 
 if (_className == "") exitWith { [] };
 
-// Check addon config first; fall back to mission config for mission-only tracks.
-// Source selection for playback is handled by the caller via the soundFile path.
-private _config = configFile >> "CfgMusic" >> _className;
+// Check mission config first — mission CfgMusic overrides addon CfgMusic for the
+// same class name, matching how playMusic resolves the class at runtime.
+private _config = missionConfigFile >> "CfgMusic" >> _className;
 if (!isClass _config) then {
-    _config = missionConfigFile >> "CfgMusic" >> _className;
+    _config = configFile >> "CfgMusic" >> _className;
 };
 
 if (!isClass _config) exitWith { [] };


### PR DESCRIPTION
Fixed bug with playMusic using a file path. Clarify mission music behavior in documentation and code, ensuring addon tracks are hidden when class names conflict with mission definitions.